### PR TITLE
pdfsizeopt-jb2.sh script and jpeg2000 support

### DIFF
--- a/README
+++ b/README
@@ -38,7 +38,7 @@ If you want to encode an image as jbig2 (can be view in STDU Viewer) run:
 
 $ jbig2 -s feyn.tif >feyn.jb2
 
-Repack large pdf file created with djvu2pdf or tiff2pdf using jbig2 compression for gray scale images and keep your
-pdf title page packed as colored jpeg. Depends on ImageMagic installed.
+Repack large pdf file created with djvu2pdf or tiff2pdf using jbig2 compression for gray scale
+images and keep your pdf title page packed as colored jpeg. Depends on ImageMagic installed.
 
 $ ~/[path]/pdfsizeopt-jb2.sh large.pdf

--- a/README
+++ b/README
@@ -37,3 +37,8 @@ $ jbig2 -s -S -p -v -O out.png *.jpg
 If you want to encode an image as jbig2 (can be view in STDU Viewer) run:
 
 $ jbig2 -s feyn.tif >feyn.jb2
+
+Repack large pdf file created with djvu2pdf or tiff2pdf using jbig2 compression for gray scale images and keep your
+pdf title page packed as colored jpeg. Depends on ImageMagic installed.
+
+$ ~/[path]/pdfsizeopt-jb2.sh large.pdf

--- a/pdf.py
+++ b/pdf.py
@@ -146,7 +146,13 @@ def ref(x):
 #   in pixels
 # density_type
 #   1 - Pixels per inch (2.54 cm)
-#
+# dpi_x, dpi_y
+#   density pixels per inch
+# color_space
+#   1 - grey scaled
+#   3 - RGB
+# bits_per_component
+#   8 - bits per pixel
 def get_jpg_props(buf):
   density_type = ord(buf[0x0d])
   xres, yres = struct.unpack(">HH", buf[0x0e:0x12])

--- a/pdf.py
+++ b/pdf.py
@@ -205,7 +205,7 @@ def loadimage(contents, symd):
 
     return (width, height, xres, yres, xobj)
 
-def main(symboltable='symboltable'):
+def main(symboltable='symboltable', pagefiles=glob.glob('page-*')):
   doc = Doc()
   doc.add_object(Obj({'Type' : '/Catalog', 'Outlines' : ref(2), 'Pages' : ref(3)}))
   doc.add_object(Obj({'Type' : '/Outlines', 'Count': '0'}))
@@ -213,9 +213,6 @@ def main(symboltable='symboltable'):
   doc.add_object(pages)
   symd = doc.add_object(Obj({}, file(symboltable, 'rb').read()))
   page_objs = []
-
-  with open('index', 'r') as index:
-    pagefiles=index.readlines()
 
   for p in pagefiles:
     p = p.strip()
@@ -249,10 +246,30 @@ def usage(script, msg):
   sys.stderr.write("Usage: %s [file_basename] > out.pdf\n"% script)
   sys.exit(1)
 
-
 if __name__ == '__main__':
   if sys.platform == "win32":
     import msvcrt
     msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
 
-  main("J.sym")
+  if len(sys.argv) == 2:
+    if sys.argv[1] == "index":
+      with open('index', 'r') as index:
+        pages = index.readlines()
+      sym = "J.sym"
+    else:
+      sym = sys.argv[1] + '.sym'
+      pages = glob.glob(sys.argv[1] + '.[0-9]*')
+      pages.sort()
+  elif len(sys.argv) == 1:
+    sym = 'symboltable'
+    pages = glob.glob('page-*')
+    pages.sort()
+  else:
+    usage(sys.argv[0], "wrong number of args!")
+
+  if not os.path.exists(sym):
+    usage(sys.argv[0], "symbol table %s not found!"% sym)
+  elif len(pages) == 0:
+    usage(sys.argv[0], "no pages found!")
+    
+  main(sym, pages)

--- a/pdf.py
+++ b/pdf.py
@@ -120,46 +120,6 @@ class Doc:
 def ref(x):
   return '%d 0 R' % x
 
-#
-# http://stackoverflow.com/questions/8032642
-#
-def get_image_size(fname):
-    '''Determine the image type of fhandle and return its size.
-    from draco'''
-    with open(fname, 'rb') as fhandle:
-        head = fhandle.read(24)
-        if len(head) != 24:
-            return
-        if imghdr.what(fname) == 'png':
-            check = struct.unpack('>i', head[4:8])[0]
-            if check != 0x0d0a1a0a:
-                return
-            width, height = struct.unpack('>ii', head[16:24])
-        elif imghdr.what(fname) == 'gif':
-            width, height = struct.unpack('<HH', head[6:10])
-        elif imghdr.what(fname) == 'jpeg':
-            try:
-                fhandle.seek(0) # Read 0xff next
-                size = 2
-                ftype = 0
-                while not 0xc0 <= ftype <= 0xcf:
-                    fhandle.seek(size, 1)
-                    byte = fhandle.read(1)
-                    while ord(byte) == 0xff:
-                        byte = fhandle.read(1)
-                    ftype = ord(byte)
-                    size = struct.unpack('>H', fhandle.read(2))[0] - 2
-                # We are at a SOFn block
-                fhandle.seek(1, 1)  # Skip `precision' byte.
-                height, width = struct.unpack('>HH', fhandle.read(4))
-            except Exception: #IGNORE:W0703
-                return
-        else:
-            return
-        return width, height
-
-
-
 # https://www.opennet.ru/docs/formats/jpeg.txt
 #
 # - $ff, $c0 (SOF0)

--- a/pdf.py
+++ b/pdf.py
@@ -135,7 +135,7 @@ def ref(x):
 #    - sampling factors (bit 0-3 vert., 4-7 hor.)
 #    - quantization table number
 
-def loadimage(contents, symd):
+def load_image(contents, symd):
   if contents[6:10] == "JFIF":
     pos = 0
     pos += 2
@@ -222,7 +222,7 @@ def main(symboltable='symboltable', pagefiles=glob.glob('page-*')):
       sys.stderr.write("error reading page file %s\n"% p)
       sys.exit(1)
       
-    (width, height, xres, yres, xobj) = loadimage(contents, symd)
+    (width, height, xres, yres, xobj) = load_image(contents, symd)
 
     contents = Obj({}, 'q %f 0 0 %f 0 0 cm /Im1 Do Q' % (float(width * 72) / xres, float(height * 72) / yres))
     resources = Obj({'ProcSet': '[/PDF /ImageB]',

--- a/pdf.py
+++ b/pdf.py
@@ -197,7 +197,7 @@ def load_image(contents, symd):
     if color_space == 0x03:
       color_space_pdf = "/DeviceRGB"
 
-    # sys.stderr.write("JP: %d %s %d %d %s %d %d\n" % (bpc, tt, width, height, str(len(contents)), xres, yres))
+    # sys.stderr.write("JP: %d %s %d %d %s %d %d\n" % (bpc, color_space_pdf, width, height, str(len(contents)), xres, yres))
     
     if xres == 0:
         xres = DPI

--- a/pdf.py
+++ b/pdf.py
@@ -220,7 +220,7 @@ def main(symboltable='symboltable', pagefiles=glob.glob('page-*')):
       contents = file(p, mode='rb').read()
     except IOError:
       sys.stderr.write("error reading page file %s\n"% p)
-      continue
+      sys.exit(1)
       
     (width, height, xres, yres, xobj) = loadimage(contents, symd)
 

--- a/pdf.py
+++ b/pdf.py
@@ -140,7 +140,7 @@ def load_image(contents, symd):
     pos = 0
     pos += 2
     b = contents[pos]
-    while (b and ord(b) != 0xDA):
+    while (ord(b) != 0xDA):
         while (ord(b) != 0xFF):
           b = contents[pos]
           pos = pos + 1
@@ -156,8 +156,7 @@ def load_image(contents, symd):
             t = ord(contents[pos])
             break
         else:
-            s = int(struct.unpack(">H", contents[pos:pos+2])[0])-2
-            pos += s
+            pos += int(struct.unpack(">H", contents[pos:pos+2])[0])
         b = contents[pos]
         pos = pos + 1
 

--- a/pdfsizeopt-jb2.sh
+++ b/pdfsizeopt-jb2.sh
@@ -22,7 +22,20 @@ force() {
 
   cd "$DIR" || exit 1
 
-  for f in *.png; do
+  declare -a files
+  files=(*.png)
+
+  tLen=${#files[@]}
+  let tLen=tLen-1
+
+  for (( i=0; i<=${tLen}; i++ )); do
+    if [ "$KEEPFIRST" == "YES" ] && [ $i -eq 0 ]; then
+      continue
+    fi
+    if [ "$KEEPLAST" == "YES" ] && [ $i -eq $tLen ]; then
+      continue
+    fi
+    f=${files[$i]}
     convert "$f" -monochrome "$f" || exit 1
   done
 }
@@ -89,6 +102,12 @@ case $key in
     ;;
     -m|--monochrome)
     MONOCHROME=YES
+    ;;
+    -kf|--keepfirst)
+    KEEPFIRST=YES
+    ;;
+    -kl|--keeplast)
+    KEEPLAST=YES
     ;;
     -dt|--density_text)
     DT="$2"

--- a/pdfsizeopt-jb2.sh
+++ b/pdfsizeopt-jb2.sh
@@ -46,7 +46,7 @@ compile() {
   DIR="$1"
   OUT="$2"
 
-  (cd "$DIR" && $SOURCE/pdf.py > $OUT) || exit 1
+  (cd "$DIR" && $SOURCE/pdf.py index > $OUT) || exit 1
 }
 
 usage() {

--- a/pdfsizeopt-jb2.sh
+++ b/pdfsizeopt-jb2.sh
@@ -125,9 +125,11 @@ case $key in
     MONOCHROME=YES
     ;;
     -kf|--keepfirst)
+    FORCE=YES
     KEEPFIRST=YES
     ;;
     -kl|--keeplast)
+    FORCE=YES
     KEEPLAST=YES
     ;;
     -v|--verbose)

--- a/pdfsizeopt-jb2.sh
+++ b/pdfsizeopt-jb2.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+
+SOURCE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# DPI for text
+DT=300
+# DPI for pictures
+DI=150
+
+extract() {
+  FILE=$1
+  
+  DIR=`mktemp -d ./${FILE%.*}.XXXX`
+
+  PNG="$DIR/${FILE%.*}-%04d.png"
+  convert -units PixelsPerInch -density $DT "$FILE" "$PNG" || exit 1
+  echo $DIR
+}
+
+process() {
+  DIR="$1"
+
+  cd "$DIR" || exit 1
+
+  COUNTER=0
+  for f in *.png; do
+    TYPE=`file "$f"`
+    if [[ "$TYPE" =~ "1-bit" ]]; then
+      JB2="${f%.*}.jb2"
+      mv "$f" "$JB2" || exit 1
+      printf "J.%04d\n" $COUNTER >> index
+      let COUNTER=COUNTER+1
+    else
+      JPX="${f%.*}.jpg"
+      convert -units PixelsPerInch -density $DT "$f" -resample $DIx$DI -density $DI "$JPX" || exit 1
+      rm "$f" || exit 1
+      echo ${JPX} >> index
+    fi
+  done
+
+  jbig2 -v -b J -d -p -s *.jb2 || exit 1
+  rm *.jb2 || exit 1
+}
+
+compile() {
+  DIR="$1"
+  OUT="$2"
+
+  (cd "$DIR" && $SOURCE/pdf.py > $OUT) || exit 1
+}
+
+usage() {
+  echo "Usage $0: large.pdf"
+}
+
+packages() {
+  for p in "$@"; do
+    which "$p" > /dev/null 2>&1 || (echo "Package $p not found..." && exit 1)
+  done
+}
+
+packages convert jbig2 || exit 1
+
+while [[ $# > 0 ]]; do
+key="$1"
+
+case $key in
+    -e|--extract)
+    EXTRACT=YES
+    ;;
+    -p|--process)
+    PROCESS=YES
+    ;;
+    -c|--compile)
+    COMPILE=YES
+    ;;
+    -a|--aaa)
+    AAA="$2"
+    shift # past argument
+    ;;
+    --default)
+    DEFAULT=YES
+    ;;
+    -h|--help)
+    usage
+    exit 0
+    ;;
+    *)
+    break
+    ;;
+esac
+shift # past argument or value
+done
+
+if [ "$EXTRACT" == "YES" ];then
+  extract "$@"
+  exit 0
+fi
+
+if [ "$PROCESS" == "YES" ];then
+  process "$@"
+  exit 0
+fi
+
+if [ "$COMPILE" == "YES" ];then
+  compile "$@"
+  exit 0
+fi
+
+for f in "$@"; do
+  if [ ! -e "$f" ]; then
+    echo "file not found: $f"
+    exit 1
+  fi
+  DIR=`extract "$f"`
+  process "$DIR" || exit 1
+  compile "$DIR" "$f" || exit 1
+  rm -rf "$DIR" || exit 1
+done

--- a/pdfsizeopt-jb2.sh
+++ b/pdfsizeopt-jb2.sh
@@ -170,7 +170,7 @@ if [ "$MONOCHROME" == "YES" ]; then
   exit 0
 fi
 
-if [ -z "$@" ]; then
+if [ $# -eq 0 ]; then
   usage
   exit 0
 fi

--- a/pdfsizeopt-jb2.sh
+++ b/pdfsizeopt-jb2.sh
@@ -10,7 +10,7 @@ DI=150
 extract() {
   FILE=$1
   
-  DIR=`mktemp -d ./${FILE%.*}.XXXX`
+  DIR=`mktemp -d "./${FILE%.*}.XXXX"`
 
   PNG="$DIR/${FILE%.*}-%04d.png"
   convert -units PixelsPerInch -density $DT "$FILE" "$PNG" || exit 1
@@ -46,7 +46,7 @@ compile() {
   DIR="$1"
   OUT="$2"
 
-  (cd "$DIR" && $SOURCE/pdf.py index > $OUT) || exit 1
+  (cd "$DIR" && $SOURCE/pdf.py index) > $OUT || exit 1
 }
 
 usage() {
@@ -113,7 +113,7 @@ for f in "$@"; do
     exit 1
   fi
   DIR=`extract "$f"`
-  process "$DIR" || exit 1
-  compile "$DIR" "$f" || exit 1
+  (process "$DIR") || exit 1
+  (compile "$DIR" "$f") || exit 1
   rm -rf "$DIR" || exit 1
 done

--- a/pdfsizeopt-jb2.sh
+++ b/pdfsizeopt-jb2.sh
@@ -15,8 +15,9 @@ extract() {
   FILE="$1"
 
   DIR=`mktemp -d "${FILE%.*}.XXXX"`
+  NAME=$(basename "$FILE")
 
-  PNG="$DIR/${FILE%.*}-%04d.png"
+  PNG="$DIR/${NAME%.*}-%04d.png"
   convert -units PixelsPerInch -density $DT "$FILE" "$PNG" || exit 1
   echo "$DIR"
 }

--- a/pdfsizeopt-jb2.sh
+++ b/pdfsizeopt-jb2.sh
@@ -6,6 +6,10 @@ SOURCE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DT=300
 # DPI for pictures
 DI=150
+# default convert images to monochrome
+MONOCHROME=YES
+# default verbose
+VERBOSE=YES
 
 extract() {
   FILE="$1"
@@ -89,7 +93,7 @@ usage() {
   echo "Options:"
   echo -e "\t-dt|--density_text\tSet DPI for text contaned images (300)"
   echo -e "\t-di|--density_image\tSet DPI for image contaned images (150)"
-  echo -e "\t-m|--monochrome\tForce convert images to monochrome"
+  echo -e "\t-k|--keep\tDo not perfome convert images to monochrome step"
   echo -e "\t\t-kf|--keepfirst\tDo not monochrome first image in list (usually cover jpg)"
   echo -e "\t\t-kl|--keeplast\tDo not monochrome last image in list (usually cover jpg)"
 }
@@ -115,19 +119,17 @@ case $key in
     -c|--compile)
     COMPILE=YES
     ;;
-    -m|--monochrome)
-    MONOCHROME=YES
+    -k|--keep)
+    MONOCHROME=NO
     ;;
     -kf|--keepfirst)
-    MONOCHROME=YES
     KEEPFIRST=YES
     ;;
     -kl|--keeplast)
-    MONOCHROME=YES
     KEEPLAST=YES
     ;;
-    -v|--verbose)
-    VERBOSE=YES
+    -q|--quiet)
+    VERBOSE=NO
     ;;
     -dt|--density_text)
     DT="$2"

--- a/pdfsizeopt-jb2.sh
+++ b/pdfsizeopt-jb2.sh
@@ -17,6 +17,16 @@ extract() {
   echo "$DIR"
 }
 
+force() {
+  DIR="$1"
+
+  cd "$DIR" || exit 1
+
+  for f in *.png; do
+    convert "$f" -monochrome "$f" || exit 1
+  done
+}
+
 process() {
   DIR="$1"
 
@@ -74,6 +84,12 @@ case $key in
     -c|--compile)
     COMPILE=YES
     ;;
+    -f|--force)
+    FORCE=YES
+    ;;
+    -m|--monochrome)
+    MONOCHROME=YES
+    ;;
     -dt|--density_text)
     DT="$2"
     shift # past argument
@@ -94,17 +110,22 @@ shift # past argument or value
 done
 
 if [ "$EXTRACT" == "YES" ];then
-  extract "$@"
+  extract "$@" || exit 1
   exit 0
 fi
 
 if [ "$PROCESS" == "YES" ];then
-  process "$@"
+  process "$@" || exit 1
   exit 0
 fi
 
 if [ "$COMPILE" == "YES" ];then
-  compile "$@"
+  compile "$@" || exit 1
+  exit 0
+fi
+
+if [ "$MONOCHROME" == "YES" ]; then
+  (force "$@") || exit 1
   exit 0
 fi
 
@@ -114,6 +135,9 @@ for f in "$@"; do
     exit 1
   fi
   DIR=`extract "$f"` || exit 1
+  if [ "$FORCE" == "YES" ]; then
+    (force "$DIR") || exit 1 
+  fi
   (process "$DIR") || exit 1
   (compile "$DIR" "$f") || exit 1
   rm -rf "$DIR" || exit 1

--- a/pdfsizeopt-jb2.sh
+++ b/pdfsizeopt-jb2.sh
@@ -6,15 +6,15 @@ SOURCE="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DT=300
 # DPI for pictures
 DI=150
-# default convert images to monochrome
-MONOCHROME=YES
+# default convert images to monochrome, YES = keep original, or NO = convert to monochrome
+KEEP=NO
 # default verbose
 VERBOSE=YES
 
 extract() {
   FILE="$1"
 
-  DIR=`mktemp -d "./${FILE%.*}.XXXX"`
+  DIR=`mktemp -d "${FILE%.*}.XXXX"`
 
   PNG="$DIR/${FILE%.*}-%04d.png"
   convert -units PixelsPerInch -density $DT "$FILE" "$PNG" || exit 1
@@ -87,6 +87,7 @@ usage() {
   echo ""
   echo "Steps:"
   echo -e "\t-e|--extract\tProduce 'extract' pdf images to directory and exit"
+  echo -e "\t-m|--monochrome\tProduce 'monochrome' step"
   echo -e "\t-p|--process\tProduce 'process' identify images and create jb2 data and exit"
   echo -e "\t-c|--compile\tProduce 'compile' step. Create pdf from directory"
   echo ""
@@ -113,6 +114,9 @@ case $key in
     -e|--extract)
     EXTRACT=YES
     ;;
+    -m|--monochrome)
+    MONOCHROME=YES
+    ;;
     -p|--process)
     PROCESS=YES
     ;;
@@ -120,7 +124,7 @@ case $key in
     COMPILE=YES
     ;;
     -k|--keep)
-    MONOCHROME=NO
+    KEEP=YES
     ;;
     -kf|--keepfirst)
     KEEPFIRST=YES
@@ -155,6 +159,11 @@ if [ "$EXTRACT" == "YES" ];then
   exit 0
 fi
 
+if [ "$MONOCHROME" == "YES" ];then
+  monochrome "$@" || exit 1
+  exit 0
+fi
+
 if [ "$PROCESS" == "YES" ];then
   process "$@" || exit 1
   exit 0
@@ -177,7 +186,7 @@ for f in "$@"; do
   fi
   [ "$VERBOSE" == "YES" ] && echo "extract: $f"
   DIR=`extract "$f"` || exit 1
-  if [ "$MONOCHROME" == "YES" ]; then
+  if [ "$KEEP" == "NO" ]; then
     (monochrome "$DIR") || exit 1 
   fi
   (process "$DIR") || exit 1

--- a/pdfsizeopt-jb2.sh
+++ b/pdfsizeopt-jb2.sh
@@ -130,7 +130,7 @@ if [ "$MONOCHROME" == "YES" ]; then
 fi
 
 for f in "$@"; do
-  if [ ! -e "$f" ]; then
+  if [ ! -f "$f" ]; then
     echo "file not found: $f"
     exit 1
   fi

--- a/pdfsizeopt-jb2.sh
+++ b/pdfsizeopt-jb2.sh
@@ -17,7 +17,7 @@ extract() {
   echo "$DIR"
 }
 
-force() {
+monochrome() {
   DIR="$1"
 
   cd "$DIR" || exit 1
@@ -85,14 +85,11 @@ usage() {
   echo -e "\t-e|--extract\tProduce 'extract' pdf images to directory and exit"
   echo -e "\t-p|--process\tProduce 'process' identify images and create jb2 data and exit"
   echo -e "\t-c|--compile\tProduce 'compile' step. Create pdf from directory"
-  echo -e "\t-m|--monochrome\tProduce 'monochrome' step. Monochrome all images in target directory"
-  echo -e "\t\t-kf|--keepfirst\tDo not monochrome first image in list (usually cover jpg)"
-  echo -e "\t\t-kl|--keeplast\tDo not monochrome last image in list (usually cover jpg)"
   echo ""
   echo "Options:"
   echo -e "\t-dt|--density_text\tSet DPI for text contaned images (300)"
   echo -e "\t-di|--density_image\tSet DPI for image contaned images (150)"
-  echo -e "\t-f|--force\tForce convert images to monochrome"
+  echo -e "\t-m|--monochrome\tForce convert images to monochrome"
   echo -e "\t\t-kf|--keepfirst\tDo not monochrome first image in list (usually cover jpg)"
   echo -e "\t\t-kl|--keeplast\tDo not monochrome last image in list (usually cover jpg)"
 }
@@ -118,18 +115,15 @@ case $key in
     -c|--compile)
     COMPILE=YES
     ;;
-    -f|--force)
-    FORCE=YES
-    ;;
     -m|--monochrome)
     MONOCHROME=YES
     ;;
     -kf|--keepfirst)
-    FORCE=YES
+    MONOCHROME=YES
     KEEPFIRST=YES
     ;;
     -kl|--keeplast)
-    FORCE=YES
+    MONOCHROME=YES
     KEEPLAST=YES
     ;;
     -v|--verbose)
@@ -169,11 +163,6 @@ if [ "$COMPILE" == "YES" ];then
   exit 0
 fi
 
-if [ "$MONOCHROME" == "YES" ]; then
-  (force "$@") || exit 1
-  exit 0
-fi
-
 if [ $# -eq 0 ]; then
   usage
   exit 0
@@ -186,8 +175,8 @@ for f in "$@"; do
   fi
   [ "$VERBOSE" == "YES" ] && echo "extract: $f"
   DIR=`extract "$f"` || exit 1
-  if [ "$FORCE" == "YES" ]; then
-    (force "$DIR") || exit 1 
+  if [ "$MONOCHROME" == "YES" ]; then
+    (monochrome "$DIR") || exit 1 
   fi
   (process "$DIR") || exit 1
   (compile "$DIR" "$f") || exit 1

--- a/pdfsizeopt-jb2.sh
+++ b/pdfsizeopt-jb2.sh
@@ -46,7 +46,7 @@ compile() {
   DIR="$1"
   OUT="$2"
 
-  (cd "$DIR" && $SOURCE/pdf.py index) > $OUT || exit 1
+  (cd "$DIR" && $SOURCE/pdf.py index) > "$OUT" || exit 1
 }
 
 usage() {
@@ -112,7 +112,7 @@ for f in "$@"; do
     echo "file not found: $f"
     exit 1
   fi
-  DIR=`extract "$f"`
+  DIR=`extract "$f"` || exit 1
   (process "$DIR") || exit 1
   (compile "$DIR" "$f") || exit 1
   rm -rf "$DIR" || exit 1

--- a/pdfsizeopt-jb2.sh
+++ b/pdfsizeopt-jb2.sh
@@ -73,6 +73,8 @@ compile() {
   DIR="$1"
   OUT="$2"
 
+  [ "$VERBOSE" == "YES" ] && echo "compile: $OUT"
+
   (cd "$DIR" && $SOURCE/pdf.py index) > "$OUT" || exit 1
 }
 

--- a/pdfsizeopt-jb2.sh
+++ b/pdfsizeopt-jb2.sh
@@ -57,9 +57,9 @@ process() {
       let COUNTER=COUNTER+1
     else
       JPX="${f%.*}.jpg"
-      convert -units PixelsPerInch -density $DT "$f" -resample $DIx$DI -density $DI "$JPX" || exit 1
+      convert -units PixelsPerInch -density $DT "$f" -background white -alpha remove -resample $DIx$DI -density $DI "$JPX" || exit 1
       rm "$f" || exit 1
-      echo ${JPX} >> index
+      echo "${JPX}" >> index
     fi
   done
 

--- a/pdfsizeopt-jb2.sh
+++ b/pdfsizeopt-jb2.sh
@@ -14,7 +14,7 @@ extract() {
 
   PNG="$DIR/${FILE%.*}-%04d.png"
   convert -units PixelsPerInch -density $DT "$FILE" "$PNG" || exit 1
-  echo $DIR
+  echo "$DIR"
 }
 
 process() {
@@ -74,12 +74,13 @@ case $key in
     -c|--compile)
     COMPILE=YES
     ;;
-    -a|--aaa)
-    AAA="$2"
+    -dt|--density_text)
+    DT="$2"
     shift # past argument
     ;;
-    --default)
-    DEFAULT=YES
+    -di|--density_image)
+    DI="$2"
+    shift # past argument
     ;;
     -h|--help)
     usage


### PR DESCRIPTION
- new script which helps to repack existing pdf's and reduce it's size
- pdf.py new input image format jpeg2000 for PDF colorer title pages
