### PR TITLE
A switch to set dpi for images w/o dpi information.

### DIFF
--- a/src/jbig2.cc
+++ b/src/jbig2.cc
@@ -55,6 +55,7 @@ usage(const char *argv0) {
   fprintf(stderr, "  -S: remove images from mixed input and save separately\n");
   fprintf(stderr, "  -j --jpeg-output: write images from mixed input as JPEG\n");
   fprintf(stderr, "  -a --auto-thresh: use automatic thresholding in symbol encoder\n");
+  fprintf(stderr, "  -D --dpi: force dpi\n");
   fprintf(stderr, "  --no-hash: disables use of hash function for automatic thresholding\n");
   fprintf(stderr, "  -V --version: version info\n");
   fprintf(stderr, "  -v: be verbose\n");
@@ -218,6 +219,7 @@ main(int argc, char **argv) {
   bool segment = false;
   bool auto_thresh = false;
   bool hash = true;
+  int dpi = 0;
   int i;
 
   #ifdef WIN32
@@ -353,6 +355,24 @@ main(int argc, char **argv) {
       continue;
     }
 
+    if (strcmp(argv[i], "-D") == 0 ||
+        strcmp(argv[i], "--dpi") == 0) {
+      char *endptr;
+      long t_dpi = strtol(argv[i+1], &endptr, 10);
+      if (*endptr) {
+	fprintf(stderr, "Cannot parse int value: %s\n", argv[i+1]);
+	usage(argv[0]);
+	return 1;
+      }
+      if (t_dpi <= 0 || t_dpi > 9600) {
+	fprintf(stderr, "Invalid dpi: (1..9600)\n");
+	return 12;
+      } 
+      dpi = (int)t_dpi;
+      i++;
+      continue;
+    }
+
     break;
   }
 
@@ -400,6 +420,11 @@ main(int argc, char **argv) {
       numsubimages = 0;
     } else {
       source = pixReadTiff(argv[i], subimage++);
+    }
+
+    if (dpi != 0 && source->xres == 0 && source->yres == 0) {
+      source->xres = dpi;
+      source->yres = dpi;
     }
 
     if (!source) return 3;


### PR DESCRIPTION
I've been creating pdf's from portable bitmaps, but I couldn't set resolution. I've added a switch to set resolution, currently it sets dpi if original image has no dpi information.
