### PR TITLE
README: unescape &gt;

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,5 @@ $ jbig2 -s -S -p -v -O out.png *.jpg
 If you want to encode an image as jbig2 (can be view in STDU Viewer) run:
 
 ```
-$ jbig2 -s feyn.tif &gt;feyn.jb2
+$ jbig2 -s feyn.tif >feyn.jb2
 ```


### PR DESCRIPTION
Within Markdown code blocks, `>` are automatically escaped, so you shouldn't escape them on your own.