### PR TITLE
Add support for standalone .jb2

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,5 @@ $ jbig2 -s -S -p -v -O out.png *.jpg
 If you want to encode an image as jbig2 (can be view in STDU Viewer) run:
 
 ```
-$ jbig2 -s feyn.tif &gt;feyn.jb2
+$ jbig2 -s feyn.tif > feyn.jb2
 ```

--- a/configure.ac
+++ b/configure.ac
@@ -78,9 +78,9 @@ AC_CHECK_LIB([lept], [findFileFormatStream], [], [
 			exit -1
 			])
 AC_CHECK_FUNCS(expandBinaryPower2Low,,)
-# test for function - it should detect leptonica dependecies
+# test for function - it should detect leptonica dependencies
 
-# Check for possible dependancies of leptonica.
+# Check for possible dependencies of leptonica.
 # Because at the moment there is no way how to identify used libraries
 # all presented libraries will be used...
 AC_CHECK_LIB([tiff], TIFFOpen )

--- a/doc/jbig2enc.html
+++ b/doc/jbig2enc.html
@@ -77,7 +77,7 @@
     <h5>Symbol retention</h5>
 
     <p>Symbol retention is the process of compressing multi-page documents by
-    extracting the symbols from all the pages at once and classifing them all
+    extracting the symbols from all the pages at once and classifying them all
     together. Thus we only have to encoding a single letter &ldquo;a&rdquo; for
     the whole document (in an ideal world).</p>
 
@@ -95,7 +95,7 @@
     <p>Symbol encoding is lossy because of noise, which is classified away and
     also because the symbol classifier is imperfect. Refinement allows us, when
     placing a symbol on the page, to encode the difference between the actual
-    symbol at that location, and what the classifer told us was &ldquo;close
+    symbol at that location, and what the classifier told us was &ldquo;close
     enough&rdquo;. We can choose to do this for each symbol on the page, so we
     don't have to refine when we are only a couple of pixel off. If we refine
     whenever we a wrong pixel, we have lossless encoding using symbols.</p>

--- a/pdf.py
+++ b/pdf.py
@@ -22,6 +22,7 @@ import re
 import struct
 import glob
 import os
+import platform
 
 # This is a very simple script to make a PDF file out of the output of a
 # multipage symbol compression.
@@ -29,27 +30,30 @@ import os
 # python pdf.py output > out.pdf
 
 dpi = 72
+ispy2 = platform.python_version_tuple()[0]=='2'
+ispy3 = platform.python_version_tuple()[0]=='3'
 
 class Ref:
   def __init__(self, x):
     self.x = x
-  def __str__(self):
-    return "%d 0 R" % self.x
+
+  def get_bytes(self):
+    return b"%d 0 R" % self.x
 
 class Dict:
   def __init__(self, values = {}):
     self.d = {}
     self.d.update(values)
 
-  def __str__(self):
-    s = ['<< ']
+  def get_bytes(self):
+    s = [b'<< ']
     for (x, y) in self.d.items():
-      s.append('/%s ' % x)
-      s.append(str(y))
-      s.append("\n")
-    s.append(">>\n")
+      s.append(b'/%s ' % x.encode())
+      s.append(y.encode())
+      s.append(b"\n")
+    s.append(b">>\n")
 
-    return ''.join(s)
+    return b''.join(s)
 
 global_next_id = 1
 
@@ -65,16 +69,19 @@ class Obj:
     self.id = global_next_id
     global_next_id += 1
 
-  def __str__(self):
+  def get_bytes(self):
     s = []
-    s.append(str(self.d))
+    s.append(self.d.get_bytes())
     if self.stream is not None:
-      s.append('stream\n')
-      s.append(self.stream)
-      s.append('\nendstream\n')
-    s.append('endobj\n')
+      s.append(b'stream\n')
+      if ispy3 and isinstance(self.stream, str):
+        s.append(self.stream.encode())
+      else:
+        s.append(self.stream)
+      s.append(b'\nendstream\n')
+    s.append(b'endobj\n')
 
-    return ''.join(s)
+    return b''.join(s)
 
 class Doc:
   def __init__(self):
@@ -89,7 +96,7 @@ class Doc:
     self.pages.append(o)
     return self.add_object(o)
 
-  def __str__(self):
+  def get_bytes(self):
     a = []
     j = [0]
     offsets = []
@@ -97,27 +104,26 @@ class Doc:
     def add(x):
       a.append(x)
       j[0] += len(x) + 1
-    add('%PDF-1.4')
+    add(b'%PDF-1.4')
     for o in self.objs:
       offsets.append(j[0])
-      add('%d 0 obj' % o.id)
-      add(str(o))
+      add(b'%d 0 obj' % o.id)
+      add(o.get_bytes())
     xrefstart = j[0]
-    a.append('xref')
-    a.append('0 %d' % (len(offsets) + 1))
-    a.append('0000000000 65535 f ')
+    a.append(b'xref')
+    a.append(b'0 %d' % (len(offsets) + 1))
+    a.append(b'0000000000 65535 f ')
     for o in offsets:
-      a.append('%010d 00000 n ' % o)
-    a.append('')
-    a.append('trailer')
-    a.append('<< /Size %d\n/Root 1 0 R >>' % (len(offsets) + 1))
-    a.append('startxref')
-    a.append(str(xrefstart))
-    a.append('%%EOF')
+      a.append(b'%010d 00000 n ' % o)
+    a.append(b'')
+    a.append(b'trailer')
+    a.append(b'<< /Size %d\n/Root 1 0 R >>' % (len(offsets) + 1))
+    a.append(b'startxref')
+    a.append(b'%d' % xrefstart)
+    a.append(b'%%EOF')
 
     # sys.stderr.write(str(offsets) + "\n")
-
-    return '\n'.join(a)
+    return b'\n'.join(a)
 
 def ref(x):
   return '%d 0 R' % x
@@ -128,22 +134,22 @@ def main(symboltable='symboltable', pagefiles=glob.glob('page-*')):
   doc.add_object(Obj({'Type' : '/Outlines', 'Count': '0'}))
   pages = Obj({'Type' : '/Pages'})
   doc.add_object(pages)
-  symd = doc.add_object(Obj({}, file(symboltable, 'rb').read()))
+  symd = doc.add_object(Obj({}, open(symboltable, 'rb').read()))
   page_objs = []
 
   pagefiles.sort()
   for p in pagefiles:
     try:
-      contents = file(p, mode='rb').read()
+      contents = open(p, "rb").read()
     except IOError:
       sys.stderr.write("error reading page file %s\n"% p)
       continue
-    (width, height, xres, yres) = struct.unpack('>IIII', contents[11:27])
-
-    if xres == 0:
-        xres = dpi
-    if yres == 0:
-        yres = dpi
+    (width, height,xres,yres) = struct.unpack('>IIII', contents[11:27])
+    
+    if xres==0:
+      xres=dpi
+    if yres==0:
+      yres=dpi
 
     xobj = Obj({'Type': '/XObject', 'Subtype': '/Image', 'Width':
         str(width), 'Height': str(height), 'ColorSpace': '/DeviceGray',
@@ -162,7 +168,13 @@ def main(symboltable='symboltable', pagefiles=glob.glob('page-*')):
     pages.d.d['Count'] = str(len(page_objs))
     pages.d.d['Kids'] = '[' + ' '.join([ref(x.id) for x in page_objs]) + ']'
 
-  print str(doc)
+  doc_bytes = doc.get_bytes()
+  if ispy2:
+    print(doc_bytes)
+  elif ispy3:
+    sys.stdout.buffer.write(doc_bytes)
+  else:
+    raise Exception("unexpected python version: %s" % platform.python_version_tuple()[0])
 
 
 def usage(script, msg):
@@ -173,7 +185,7 @@ def usage(script, msg):
 
 
 if __name__ == '__main__':
-  if sys.platform == "win32":
+  if ispy2 and sys.platform == "win32":
     import msvcrt
     msvcrt.setmode(sys.stdout.fileno(), os.O_BINARY)
 

--- a/src/jbig2arith.h
+++ b/src/jbig2arith.h
@@ -179,7 +179,7 @@ void jbig2enc_dealloc(struct jbig2enc_ctx *ctx);
 void jbig2enc_flush(struct jbig2enc_ctx *ctx);
 
 // -----------------------------------------------------------------------------
-// Reset the arithmetic coder back to a init state
+// Reset the arithmetic coder back to an init state
 // -----------------------------------------------------------------------------
 void jbig2enc_reset(struct jbig2enc_ctx *ctx);
 

--- a/src/jbig2enc.cc
+++ b/src/jbig2enc.cc
@@ -149,7 +149,7 @@ print_list(std::list<int> &l) {
 #endif
 
 // -----------------------------------------------------------------------------
-// unite_templates unites templates of the same character to chosen charater
+// unite_templates unites templates of the same character to chosen character
 // template
 //
 //   ctx: structure containing templates of symbols.
@@ -367,7 +367,7 @@ jbig2enc_auto_threshold(struct jbig2ctx *ctx) {
   }
 }
 
-#if defined(HASH_DEBUGING)
+#if defined(HASH_DEBUGGING)
 static void
 print_hash_map(std::map<unsigned int, list<int> > &hashed_templates) {
   std::map<unsigned int, list<int> >::iterator it;
@@ -430,7 +430,7 @@ jbig2enc_auto_threshold_using_hash(struct jbig2ctx *ctx) {
     count_hash(pixa->pix[i], hashed_templates, i);
   }
 
-  #ifdef HASH_DEBUGING
+  #ifdef HASH_DEBUGGING
     print_hash_map(hashed_templates);
   #endif
 
@@ -530,7 +530,7 @@ uint8_t *
 jbig2_pages_complete(struct jbig2ctx *ctx, int *const length) {
   /*
      Graying support - disabled.
-     It's not very clear that graying actaully buys you much extra quality
+     It's not very clear that graying actually buys you much extra quality
      above pick-the-first. Also, aligning the gray glyphs requires the
      original source image.
 

--- a/src/jbig2sym.cc
+++ b/src/jbig2sym.cc
@@ -258,7 +258,7 @@ jbig2enc_textregion(struct jbig2enc_ctx *restrict ctx,
     myiota(syms.begin(), syms.end(), 0);
   } else {
     // fill syms with the component numbers from the comps array because ll is
-    // absolutly indexed in this case (absolute: over the whole multi-page
+    // absolutely indexed in this case (absolute: over the whole multi-page
     // document)
     syms = comps;
   }

--- a/src/jbig2sym.h
+++ b/src/jbig2sym.h
@@ -23,7 +23,7 @@ struct jbig2enc_ctx;
 // -----------------------------------------------------------------------------
 // Write a symbol table.
 //
-// symbols: A 2d array. The first dimention is of different classes of symbols.
+// symbols: A 2d array. The first dimension is of different classes of symbols.
 //          Then, for each class, there are all the examples of that class. The
 //          first member of the class is taken as the exemplar.
 // symbol_list: a list of symbols to encode


### PR DESCRIPTION
Add `-s` switch for inputs without a global symbol table (standalone JBIG2 compressed pages).
Especially relevant for pages which are individually losslessly compressed by jbig2enc.

Fixes #24.