### PR TITLE
Fix build with Leptonica >=1.83

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -73,7 +73,7 @@ AC_CONFIG_COMMANDS([libtool-rpath-patch],
 	fi],
 [libtool_patch_use_rpath=$enable_rpath])
 
-AC_CHECK_LIB([lept], [findFileFormatStream], [], [
+AC_CHECK_LIB([leptonica], [findFileFormatStream], [], [
 			echo "Error! Leptonica not detected."
 			exit -1
 			])

--- a/src/jbig2.cc
+++ b/src/jbig2.cc
@@ -29,6 +29,9 @@
 #endif
 
 #include <leptonica/allheaders.h>
+#if (LIBLEPT_MAJOR_VERSION == 1 && LIBLEPT_MINOR_VERSION >= 83) || LIBLEPT_MAJOR_VERSION > 1
+#include "leptonica/pix_internal.h"
+#endif
 
 #include "jbig2enc.h"
 

--- a/src/jbig2enc.cc
+++ b/src/jbig2enc.cc
@@ -24,6 +24,10 @@
 #include <string.h>
 
 #include <leptonica/allheaders.h>
+#if (LIBLEPT_MAJOR_VERSION == 1 && LIBLEPT_MINOR_VERSION >= 83) || LIBLEPT_MAJOR_VERSION > 1
+#include "leptonica/pix_internal.h"
+#include "leptonica/array_internal.h"
+#endif
 
 #include <math.h>
 #if defined(sun)
@@ -206,7 +210,11 @@ unite_templates(struct jbig2ctx *ctx,
         numaSetValue(ctx->classer->naclass, i, new_representant);
       }
     }
+#if (LIBLEPT_MAJOR_VERSION == 1 && LIBLEPT_MINOR_VERSION >= 83) || LIBLEPT_MAJOR_VERSION > 1
+    ctx->classer->pixat->pix[new_representant]->refcount += ctx->classer->pixat->pix[second_template]->refcount;
+#else
     pixChangeRefcount(ctx->classer->pixat->pix[new_representant],pixGetRefcount(ctx->classer->pixat->pix[second_template]));
+#endif
   }
   return 0;
 }

--- a/src/jbig2sym.cc
+++ b/src/jbig2sym.cc
@@ -29,6 +29,10 @@
 #include <stdio.h>
 
 #include <leptonica/allheaders.h>
+#if (LIBLEPT_MAJOR_VERSION == 1 && LIBLEPT_MINOR_VERSION >= 83) || LIBLEPT_MAJOR_VERSION > 1
+#include "leptonica/pix_internal.h"
+#include "leptonica/array_internal.h"
+#endif
 
 #include <math.h>
 


### PR DESCRIPTION
From leptonica 1.83 release notes:
 * Use stdatomic.h to make cloning string safe. Remove all *GetRefcount() and *ChangeRefcount() accessors.
 * Remove information about fields in many structs from the public interface allheaders.h, instead putting them in internal files pix_internal.h, array_internal.h and ccbord_internal.h.