### PR TITLE
jbig2enc.html: add missing verb

### DIFF
--- a/doc/jbig2enc.html
+++ b/doc/jbig2enc.html
@@ -98,7 +98,7 @@
     symbol at that location, and what the classifer told us was &ldquo;close
     enough&rdquo;. We can choose to do this for each symbol on the page, so we
     don't have to refine when we are only a couple of pixel off. If we refine
-    whenever we a wrong pixel, we have lossless encoding using symbols.</p>
+    whenever we see a wrong pixel, we have lossless encoding using symbols.</p>
 
     <h5>Halftoning</h5>
 


### PR DESCRIPTION
Was going to quote it on Wikipedia. Found a missing verb instead.

P.S. Mind doing some stuff to make GitHub host this page? I think you can go the repo options and make it serve what's under  `doc` at https://agl.github.io/jbig2enc. The stuff would then be at https://agl.github.io/jbig2enc/jbig2enc.html. Not optimal, but better than this.