### PR TITLE
Add support for standalone (lossless generic region encoding) .jb2 - v0.29/Python 3 codebase

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Misty De Meo <mistydemeo@gmail.com>
 zdenop <zdenop@gmail.com>
 Steven Lee http://www.rubypdf.com
 Radim Hatlapatka <hata.radim@gmail.com>
+Lee Yingtong Li <runassudo@yingtongli.me>


### PR DESCRIPTION
Adapts @akobel's previous PR #77 to the current v0.29/Python 3 codebase. Adds a `-s` switch for inputs without a global symbol table (standalone JBIG2 compressed pages, especially lossless generic region encoding).

I believe this fixes issue #24 (but that discussion is not publicly accessible, though has been archived at https://web.archive.org/web/20201217210336/https://github.com/agl/jbig2enc/issues/24).

The approach and syntax are gratefully adapted from @akobel at https://github.com/agl/jbig2enc/pull/77/commits/ce8913dbf612d23e2718c56ab8faeb977537863a, which was in turn inspired by @kmlyvens at https://gist.github.com/kmlyvens/b532c7aec2fe2bd8214ae2b3faf8f741.