### PR TITLE
fix MSVC compile error due to 'verbose' being defined in the MSVC system header files

### DIFF
--- a/src/jbig2.cc
+++ b/src/jbig2.cc
@@ -17,6 +17,8 @@
 
 #include <vector>
 
+#undef verbose
+
 #include <sys/types.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/jbig2enc.cc
+++ b/src/jbig2enc.cc
@@ -47,6 +47,8 @@
 #include "jbig2segments.h"
 #include "jbig2comparator.h"
 
+#undef verbose
+
 // -----------------------------------------------------------------------------
 // Returns the version identifier as a static string.
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
As the commit msgs say:

---

* fix MSVC compile error due to 'verbose' being defined in the MSVC system header files, which resulting in MSVC2022 producing some *extremely weird* error reports:

        jbig2enc\src\jbig2enc.cc(542,68): error C2143: syntax error: missing ')' before '-'
        jbig2enc\src\jbig2enc.cc(542,68): error C2143: syntax error: missing ';' before '-'
        jbig2enc\src\jbig2enc.cc(542,68): error C2059: syntax error: '-'
        jbig2enc\src\jbig2enc.cc(542,75): error C2059: syntax error: ')'
        jbig2enc\src\jbig2enc.cc(542,77): error C2143: syntax error: missing ';' before '{'
        jbig2enc\src\jbig2enc.cc(542,77): error C2447: '{': missing function header (old-style formal list?)

* fix compile-time clash with `verbose` defined in the `vector` system header file (MSVC/Win32)

---

(MSVC x64 debug build, custom MSVC project which has the warning levels dialed up to GCC `pedantic` levels; if you haven't seen this error yourself yet, it's possible my project settings trigger a subtly different preprocessor path through the MSVC system header files 🤔 

> effective C/C++ command line:
>
> /permissive- /MP /ifcOutput "Z:\lib\tooling\qiqqa\MuPDF\platform\win32\obj\Debug-Unicode-64bit-x64\StaticLibrary-libjbig2enc\" /GS /Wall /wd"4774" /wd"4711" /wd"4295" /wd"4152" /wd"4200" /wd"4355" /wd"5246" /wd"5267" /wd"4866" /wd"4868" /wd"5220" /wd"4582" /wd"4583" /wd"4435" /wd"4619" /wd"5029" /wd"5266" /wd"4371" /wd"5031" /wd"4946" /wd"5250" /wd"5262" /wd"5038" /wd"5219" /wd"4710" /wd"4388" /wd"4324" /wd"4242" /wd"4365" /wd"4623" /wd"4626" /wd"5026" /wd"5027" /wd"4625" /wd"4514" /wd"4464" /wd"4061" /wd"4668" /wd"5045" /wd"4820" /wd"4180" /wd"4244" /wd"4018" /wd"4267" /wd"5105" /wd"4100" /wd"4127" /wd"4206" /wd"4102" /wd"4146" /wd"4189" /wd"4245" /wd"4334" /wd"4389" /wd"4457" /wd"4458" /wd"4456" /wd"4459" /wd"4701" /wd"4702" /wd"4706" /Gy /Zc:wchar_t /I"../../include/system-override" /I"." /I"../../thirdparty/owemdjee/jbig2enc/src" /I"../../thirdparty/lcms2/include" /I"../../scripts/freetype" /I"../../scripts/libpng" /I"../../scripts/libtiff" /I"../../scripts/libjpeg-turbo" /I"../../thirdparty/jbig2dec" /I"../../thirdparty/owemdjee/libjpeg-turbo/src" /I"../../thirdparty/openjpeg/src/lib/openjp2" /I"../../thirdparty/freetype/include" /I"../../thirdparty/freetype/include/freetype" /I"../../thirdparty/harfbuzz/src" /I"../../thirdparty/gumbo-parser/src" /I"../../thirdparty/gumbo-parser/visualc/include" /I"../../thirdparty/libpng" /I"../../thirdparty/libtiff/libtiff" /I"../../thirdparty/zlib" /I"../../include/" /I"../../include/mupdf" /I"../../scripts/zlib" /I"../../thirdparty/owemdjee/zstd/lib" /I"../../thirdparty/owemdjee/libwebp/src" /I"../../thirdparty/owemdjee/plf_nanotimer" /I"../../scripts/leptonica/include" /Zi /Gm- /sdl- /Fd"Z:\lib\tooling\qiqqa\MuPDF\platform\win32\obj\Debug-Unicode-64bit-x64\StaticLibrary-libjbig2enc\libjbig2enc.pdb" /Zc:inline /fp:fast /D "HAVE_MUPDF" /D "MUJS_ALL_FILES" /D "WITH_GZFILEOP" /D "BUILD_MONOLITHIC" /D "FT2_BUILD_LIBRARY" /D "OPJ_STATIC" /D "USE_JPIP=1" /D "FT_CONFIG_MODULES_H=\"slimftmodules.h\"" /D "FT_CONFIG_OPTIONS_H=\"slimftoptions.h\"" /D "verbose=-1" /D "HAVE_FALLBACK=1" /D "HAVE_OT" /D "HAVE_UCDN" /D "HB_NO_MT" /D "hb_malloc_impl=fz_hb_malloc" /D "hb_calloc_impl=fz_hb_calloc" /D "hb_realloc_impl=fz_hb_realloc" /D "hb_free_impl=fz_hb_free" /D "HAVE_FREETYPE" /D "_WINDOWS" /D "WIN64" /D "_DEBUG" /D "GHC_DO_NOT_USE_STD_FS" /D "_SILENCE_CXX20_ATOMIC_INIT_DEPRECATION_WARNING" /D "_SILENCE_CXX23_DENORM_DEPRECATION_WARNING" /D "_CRT_SECURE_NO_WARNINGS" /D "_CRT_NONSTDC_NO_WARNINGS" /D "_CRTDBG_MAP_ALLOC" /D "_CRT_SECURE_NO_DEPRECATE" /D "_CRT_INTERNAL_NONSTDC_NAMES" /D "_USE_MATH_DEFINES" /D "_UNICODE" /D "UNICODE" /fp:except- /errorReport:prompt /GF /GT /WX- /Zc:forScope /RTC1 /std:clatest /GR /arch:AVX2 /Gd /Oy /Oi /MDd /std:c++latest /FC /Fa"Z:\lib\tooling\qiqqa\MuPDF\platform\win32\obj\Debug-Unicode-64bit-x64\StaticLibrary-libjbig2enc\" /EHa /nologo /Fo"Z:\lib\tooling\qiqqa\MuPDF\platform\win32\obj\Debug-Unicode-64bit-x64\StaticLibrary-libjbig2enc\" /Ot /Fp"Z:\lib\tooling\qiqqa\MuPDF\platform\win32\obj\Debug-Unicode-64bit-x64\StaticLibrary-libjbig2enc\libjbig2enc.pch" /diagnostics:column 
)