### PR TITLE
Meson build system

### DIFF
--- a/.github/workflows/meson.yaml
+++ b/.github/workflows/meson.yaml
@@ -1,0 +1,215 @@
+name: meson
+
+on:
+  push:
+    paths:
+      - src/**
+      - meson.build
+  pull_request:
+    paths:
+      - src/**
+      - meson.build
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    container:
+      image: 'registry.opensuse.org/opensuse/tumbleweed'
+      env:
+        CC: ${{ matrix.cc }}
+        CXX: ${{ matrix.cxx }}
+        CC_LD: ${{ matrix.ld }}
+        CXX_LD: ${{ matrix.ld }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [clang, gcc, mingw-w64-gcc]
+        include:
+          - compiler: clang
+            cc: clang
+            cxx: clang++
+            ld: lld
+            pkg:
+              - clang
+              - lld
+              - libstdc++-devel
+            args:
+              - -Db_lto_mode=thin
+              - -Db_lundef=false
+              - -Db_sanitize=address,undefined
+          - compiler: gcc
+            cc: gcc
+            cxx: g++
+            pkg:
+              - gcc-c++
+            args:
+              - -Db_sanitize=address,undefined
+          - compiler: mingw-w64-gcc
+            pkg:
+              - mingw64-cross-gcc-c++
+              - mingw64-cross-pkgconf
+              - mingw64-cross-wine
+            args:
+              - --cross-file=cross.ini
+              - --pkgconfig.relocatable
+              - -Db_lto=false
+              - --prefix
+              - $(pwd)/artifact
+    steps:
+      - name: '🛒 Install dependencies'
+        run: >
+          zypper -n in --no-recommends
+          meson
+          git-core
+          'pkgconfig(lept)'
+          ${{ join(matrix.pkg, ' ') }}
+          || [ $? -eq 107 ]
+
+      - name: '📂 Checkout'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      # checkout action UID differs from container UID
+      - name: '🙄 Tell Git to ignore workspace ownership'
+        run: git config --global --add safe.directory '*'
+
+      - name: '🧰 Write MinGW cross file'
+        if: ${{ matrix.compiler == 'mingw-w64-gcc' }}
+        run: |
+          cat << EOF > cross.ini
+          [binaries]
+          c = '/usr/bin/x86_64-w64-mingw32-gcc'
+          cpp = '/usr/bin/x86_64-w64-mingw32-g++'
+          objc = '/usr/bin/x86_64-w64-mingw32-gcc'
+          ar = '/usr/bin/x86_64-w64-mingw32-ar'
+          strip = '/usr/bin/x86_64-w64-mingw32-strip'
+          pkg-config = '/usr/bin/x86_64-w64-mingw32-pkg-config'
+          windres = '/usr/bin/x86_64-w64-mingw32-windres'
+          exe_wrapper = 'wine'
+          ld = '/usr/bin/x86_64-w64-mingw32-ld'
+
+          [properties]
+          root = '/usr/x86_64-w64-mingw32'
+          needs_exe_wrapper = true
+
+          [built-in options]
+          default_library = 'static'
+          prefer_static = true
+          c_link_args = '-static'
+          cpp_link_args = '-static'
+
+          [host_machine]
+          system = 'windows'
+          cpu_family = 'x86_64'
+          cpu = 'x86_64'
+          endian = 'little'
+          EOF
+          mkdir wineprefix
+          echo "WINEPREFIX=$(pwd)/wineprefix" >> $GITHUB_ENV
+
+      - name: '🚧 Configure build'
+        run: meson setup --buildtype debug ${{ join(matrix.args, ' ') }} build
+
+      - name: '🛠 Run build'
+        run: meson compile -C build
+
+      - name: '🔬 Run tests'
+        run: meson test -C build --print-errorlogs 'jbig2enc:'
+
+      - name: '📦 Install build artifact'
+        id: install
+        if: ${{ matrix.compiler == 'mingw-w64-gcc' }}
+        run: |
+          meson install -C build --skip-subprojects
+          cp COPYING artifact
+          echo "prjinfo=$(meson introspect --projectinfo build)" >> $GITHUB_OUTPUT
+
+      - name: '🚀 Upload build artifact'
+        if: ${{ matrix.compiler == 'mingw-w64-gcc' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: jbig2enc-${{ fromJSON(steps.install.outputs.prjinfo)['version'] }}${{ github.event.pull_request.number && format('-pr{0}', github.event.pull_request.number) || '' }}-Windows-X64-${{ matrix.compiler }}
+          path: artifact/*
+
+  windows:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['windows-2025-vs2026', 'windows-11-arm']
+    steps:
+      - name: '📂 Checkout'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: '🛒 Install dependencies'
+        run: python -m pip install meson
+
+      - name: '🚧 Configure build'
+        shell: bash
+        run: >
+          meson setup
+          --vsenv
+          --pkgconfig.relocatable
+          --buildtype debug
+          --prefix "$(pwd)/artifact"
+          build
+
+      - name: '🛠 Run build'
+        run: meson compile -C build
+
+      - name: '🔬 Run tests'
+        run: meson test -C build --print-errorlogs 'jbig2enc:'
+
+      - name: '📦 Install build artifact'
+        id: install
+        shell: bash
+        run: |
+          meson install -C build --skip-subprojects
+          cp COPYING artifact
+          echo "prjinfo=$(meson introspect --projectinfo build)" >> $GITHUB_OUTPUT
+
+      - name: '🚀 Upload build artifact'
+        uses: actions/upload-artifact@v6
+        with:
+          name: jbig2enc-${{ fromJSON(steps.install.outputs.prjinfo)['version'] }}${{ github.event.pull_request.number && format('-pr{0}', github.event.pull_request.number) || '' }}-${{ runner.os }}-${{ runner.arch }}-MSVC
+          path: artifact/*
+
+  macos:
+    runs-on: macos-26
+    steps:
+      - name: '📂 Checkout'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: '🛒 Install dependencies'
+        run: |
+          brew update
+          brew install -q meson leptonica
+
+      - name: '🚧 Configure build'
+        run: >
+          meson setup
+          --buildtype debug
+          -Db_lto_mode=thin
+          -Db_sanitize=address,undefined
+          -Db_lundef=false
+          build
+
+      - name: '🛠 Run build'
+        run: meson compile -C build
+
+      - name: '🔬 Run tests'
+        run: meson test -C build --print-errorlogs 'jbig2enc:'

--- a/INSTALL
+++ b/INSTALL
@@ -2,8 +2,8 @@
 
 ## Prerequisites
 
-* Installed [Leptonica](http://www.leptonica.org/) including development parts (e.g. libleptonica-dev)
-* Installed [cmake](https://cmake.org/) or [autotools](https://www.gnu.org/software/automake/manual/html_node/Autotools-Introduction.html)
+* Installed [Leptonica](http://www.leptonica.org/) including development parts (e.g. libleptonica-dev) - Meson will download and build it if necessary
+* Installed [cmake](https://cmake.org/) or [autotools](https://www.gnu.org/software/automake/manual/html_node/Autotools-Introduction.html) or [Meson](https://mesonbuild.com/)
 * Installed C++ compiler (GCC, Clang, or MSVC)
 * Installed [git](https://git-scm.com/)
 
@@ -22,6 +22,43 @@ make install (or: sudo make install)
 
 
 Make sure packages such as `automake`, ` libtool`, `make`, `pkg-config` and `autoconf-archive` are installed before executing the commands above.
+
+## Meson
+
+The usual way on most operating systems is:
+
+```sh
+meson setup build
+meson compile -C build
+meson install -C build
+```
+
+This will set up a build directory (called `build`), compile and install the software. Meson will ask for elevated user privileges as needed.
+
+### IDEs
+
+Some IDEs, like KDevelop, already support Meson.
+
+VSCode has an extension you can install from the marketplace. Once that is set up, you can simply open the source directory in VSCode and everything will be configured automatically.
+
+### Distributions with older Meson versions
+
+If your OS distribution does not package a new enough version of Meson, you can also use Python tools to install it:
+
+#### uv (recommended)
+
+```sh
+uv tool install meson
+```
+
+### pip
+
+```sh
+pip3 install --user meson
+```
+
+You may have to add `~/.local/bin` to your `$PATH` for it to be recognized.
+
 
 ## CMake
 

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,0 +1,6 @@
+install_data(
+    'jbig2enc.html',
+    'PATENTS',
+    install_dir: get_option('datadir') / 'doc' / meson.project_name(),
+    install_tag: 'doc',
+)

--- a/meson-support/leptonica-header.h.in
+++ b/meson-support/leptonica-header.h.in
@@ -1,0 +1,1 @@
+#include <@header@>

--- a/meson-support/version.sh
+++ b/meson-support/version.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if [ "$1" = "get-vcs" ]; then
+  git -C "$MESON_SOURCE_ROOT" describe --tags --always --dirty
+elif [ "$1" = "set-dist" ]; then
+  $MESONREWRITE --sourcedir="$MESON_PROJECT_DIST_ROOT" kwargs set project / version "$2"
+else
+  exit 1
+fi

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,82 @@
+project(
+    'jbig2enc',
+    'cpp',
+    license: 'Apache-2.0',
+    license_files: ['COPYING', 'AUTHORS'],
+    version: run_command('meson-support'/'version.sh', 'get-vcs', check: true).stdout().strip(),
+    meson_version: '>= 1.10.0',
+    default_options: {
+        'cpp_std': 'c++14',
+        'warning_level': '3',
+        'b_ndebug': 'if-release',
+        'buildtype': 'debugoptimized',
+        'b_lto': true,
+        'b_pie': true,
+        # Leptonica Wrap fallback options
+        'leptonica:warning_level': '0',
+        'leptonica:tests': 'disabled',
+        'leptonica:progs': 'disabled',
+        'leptonica:libjpeg': 'enabled',
+        'leptonica:libtiff': 'enabled',
+        'leptonica:libz': 'enabled',
+        'libjpeg-turbo:tests': 'disabled',
+        'libpng:tests': false,
+        'tiff:jpeg': 'enabled',
+        'tiff:zlib': 'enabled',
+        'leptonica:default_library': 'static',
+        'libjpeg-turbo:default_library': 'static',
+        'libpng:default_library': 'static',
+        'libtiff:default_library': 'static',
+        'libz:default_library': 'static',
+        'libjpeg-turbo:warning_level': '0',
+        'libpng:warning_level': '0',
+        'libtiff:warning_level': '0',
+        'libz:warning_level': '0',
+    },
+)
+# Cement version for dist tarballs so that git is not required.
+meson.add_dist_script('meson-support'/'version.sh', 'set-dist', meson.project_version())
+
+version_clean = meson.project_version().split('-')[0]
+version_parts = version_clean.split('.')
+# Match libtool versioning scheme.
+# This can be independent from the project version.
+so_current = version_parts[0].to_int()  # increment for all API changes
+so_revision = version_parts[1].to_int()  # always increment
+so_age = version_parts.get(2, '0').to_int()  # increment only for backwards-compatible API changes
+shlib_version = '@0@.@1@.@2@'.format(so_current - so_age, so_age, so_revision)
+
+cxx = meson.get_compiler('cpp')
+
+add_project_arguments(
+    '-DVERSION="@0@"'.format(meson.project_version()),
+    language: 'cpp',
+)
+
+lept_dep = dependency('lept', version: '>=1.74')
+dependencies = [
+    lept_dep,
+    cxx.find_library('m', required: false),
+]
+
+if host_machine.system() == 'windows'
+    dependencies += cxx.find_library('ws2_32')
+    add_project_arguments('-DWIN32', '-D_USE_MATH_DEFINES', language: 'cpp')
+    if cxx.get_id() == 'msvc'
+        add_project_link_arguments('setargv.obj', language: 'cpp')
+        add_project_arguments(
+            '-D_CRT_SECURE_NO_WARNINGS',
+            '-D_SCL_SECURE_NO_WARNINGS',
+            language: ['c', 'cpp'],
+        )
+    endif
+endif
+
+subdir('doc')
+subdir('src')
+
+install_data(
+    'jbig2topdf.py',
+    install_dir: get_option('bindir'),
+    install_tag: 'runtime',
+)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,80 @@
+if not cxx.has_header('leptonica/allheaders.h')
+    # On some platforms the .pc file points inside the `leptonica` directory.
+    # This is also true for the Wrap fallback.
+    # Just generate some wrapper headers for that case.
+    foreach h : ['allheaders.h', 'pix_internal.h', 'array_internal.h']
+        configure_file(
+            input: meson.project_source_root() / 'meson-support' / 'leptonica-header.h.in',
+            output: h,
+            build_subdir: 'leptonica',
+            configuration: {'header': h},
+        )
+    endforeach
+endif
+
+lib_src = files(
+    'jbig2arith.cc',
+    'jbig2comparator.cc',
+    'jbig2enc.cc',
+    'jbig2sym.cc',
+)
+
+if cxx.get_id() == 'msvc'
+    # TODO: Need to mark symbol visibility in header files.
+    # Meson can handle it for us:
+    # https://mesonbuild.com/Snippets-module.html#symbol_visibility_header
+    lib = static_library(
+        'jbig2enc',
+        lib_src,
+        install: true,
+        dependencies: dependencies,
+    )
+else
+    lib = library(
+        'jbig2enc',
+        lib_src,
+        soversion: shlib_version,
+        install: true,
+        dependencies: dependencies,
+    )
+endif
+
+install_headers(
+    'jbig2arith.h',
+    'jbig2comparator.h',
+    'jbig2segments.h',
+    'jbig2structs.h',
+    'jbig2sym.h',
+)
+
+exe = executable(
+    'jbig2',
+    'jbig2.cc',
+    install: true,
+    dependencies: dependencies,
+    link_with: lib,
+)
+
+test(
+    'basic',
+    exe,
+    args: [
+        '-s',
+        '-a',
+        '-v',
+        meson.project_source_root() / 'images' / 'feyn.tif',
+    ],
+)
+
+pkg = import('pkgconfig')
+pkg.generate(
+    lib,
+    description: 'JBIG2 Encoder',
+    version: version_clean,
+    license: meson.project_license()[0],
+    url: 'https://github.com/agl/jbig2enc',
+)
+
+# This makes the library usable as Meson subprorect.
+lib_dep = declare_dependency(include_directories: '.', link_with: lib)
+meson.override_dependency('jbig2enc', lib_dep)

--- a/subprojects/leptonica.wrap
+++ b/subprojects/leptonica.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = leptonica-1.84.1
+source_url = https://github.com/DanBloomberg/leptonica/releases/download/1.84.1/leptonica-1.84.1.tar.gz
+source_filename = leptonica-1.84.1.tar.gz
+source_hash = 2b3e1254b1cca381e77c819b59ca99774ff43530209b9aeb511e1d46588a64f6
+patch_filename = leptonica_1.84.1-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/leptonica_1.84.1-2/get_patch
+patch_hash = 9c270f153d6f94519118ace9a2ed3d22326eeb4f6992f0d2452d24804532a237
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/leptonica_1.84.1-2/leptonica-1.84.1.tar.gz
+wrapdb_version = 1.84.1-2
+
+[provide]
+dependency_names = lept

--- a/subprojects/libjpeg-turbo.wrap
+++ b/subprojects/libjpeg-turbo.wrap
@@ -1,0 +1,14 @@
+[wrap-file]
+directory = libjpeg-turbo-3.1.3
+source_url = https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/3.1.3/libjpeg-turbo-3.1.3.tar.gz
+source_filename = libjpeg-turbo-3.1.3.tar.gz
+source_hash = 075920b826834ac4ddf97661cc73491047855859affd671d52079c6867c1c6c0
+source_fallback_url = https://wrapdb.mesonbuild.com/v2/libjpeg-turbo_3.1.3-1/get_source/libjpeg-turbo-3.1.3.tar.gz
+patch_filename = libjpeg-turbo_3.1.3-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/libjpeg-turbo_3.1.3-1/get_patch
+patch_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libjpeg-turbo_3.1.3-1/libjpeg-turbo_3.1.3-1_patch.zip
+patch_hash = 4c552c743b6a16d3338cbee6ab1dc10333f19a72464e7b7c964f6e03d78f48df
+wrapdb_version = 3.1.3-1
+
+[provide]
+dependency_names = libjpeg, libturbojpeg

--- a/subprojects/libpng.wrap
+++ b/subprojects/libpng.wrap
@@ -1,0 +1,14 @@
+[wrap-file]
+directory = libpng-1.6.55
+source_url = https://github.com/pnggroup/libpng/archive/v1.6.55.tar.gz
+source_filename = libpng-1.6.55.tar.gz
+source_hash = 71a2c5b1218f60c4c6d2f1954c7eb20132156cae90bdb90b566c24db002782a6
+source_fallback_url = https://wrapdb.mesonbuild.com/v2/libpng_1.6.55-1/get_source/libpng-1.6.55.tar.gz
+patch_filename = libpng_1.6.55-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/libpng_1.6.55-1/get_patch
+patch_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libpng_1.6.55-1/libpng_1.6.55-1_patch.zip
+patch_hash = d5754df441e93e2e2f1dc176cc86f45ec0ef2914e9c77c1e8013c68b106d0ff5
+wrapdb_version = 1.6.55-1
+
+[provide]
+dependency_names = libpng

--- a/subprojects/libtiff.wrap
+++ b/subprojects/libtiff.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = tiff-4.7.1
+source_url = https://download.osgeo.org/libtiff/tiff-4.7.1.tar.xz
+source_filename = tiff-4.7.1.tar.gz
+source_hash = b92017489bdc1db3a4c97191aa4b75366673cb746de0dce5d7a749d5954681ba
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libtiff_4.7.1-3/tiff-4.7.1.tar.gz
+patch_filename = libtiff_4.7.1-3_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/libtiff_4.7.1-3/get_patch
+patch_hash = c452f63523f02afe44eb88511a771ba5db5ace0cef5e8c0281630421969b0a87
+wrapdb_version = 4.7.1-3
+
+[provide]
+dependency_names = libtiff-4

--- a/subprojects/zlib.wrap
+++ b/subprojects/zlib.wrap
@@ -1,0 +1,14 @@
+[wrap-file]
+directory = zlib-1.3.2
+source_url = https://zlib.net/zlib-1.3.2.tar.xz
+source_fallback_url = https://wrapdb.mesonbuild.com/v2/zlib_1.3.2-1/get_source/zlib-1.3.2.tar.xz
+source_filename = zlib-1.3.2.tar.xz
+source_hash = d7a0654783a4da529d1bb793b7ad9c3318020af77667bcae35f95d0e42a792f3
+patch_filename = zlib_1.3.2-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/zlib_1.3.2-1/get_patch
+patch_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/zlib_1.3.2-1/zlib_1.3.2-1_patch.zip
+patch_hash = 5ae7a2e92f823df118cfb8c1b23d94e3117864392b3446581d669049b2fba6dd
+wrapdb_version = 1.3.2-1
+
+[provide]
+dependency_names = zlib


### PR DESCRIPTION
Well. I was making an openSUSE package for my home repo and got a little frustrated because even though the distro isn’t doing anything unusual, neither the Autotools nor the CMake build system were usable for that without modifications. Last year I’ve decided to just port things to Meson whenever this happens, because when thousands of people use something and know it’s got problems but do nothing about it, that’s neither good nor in the spirit of free software, and build systems are the one thing nobody wants to touch because most of them suck and demand entirely too much developer time because they’re constantly broken for everyone else.

So, here’s a build system that actually works and is easy to use. Comes with Actions for Linux+MinGW, Windows and MacOS too, including packaged Windows build artifacts (addresses #117). They’re failing in this PR because ASan and UBSan are complaining, but you can see a successful run on a branch that has #125 merged [here](https://github.com/mia-0/jbig2enc/actions/runs/22763966356). I had FreeBSD in there as well and it worked, but I decided to drop it because it took forever and isn’t really worth it.

Thanks to WrapDB it will download and build Leptonica if it can’t find it on the system, so the batteries are included.

There’s also a basic test defined that just runs `jbig2` on `images/feyn.tif`, and dist tarballs that don’t require Git can be made by running `meson dist` from a configured build directory.