### PR TITLE
Meson: update leptonica wrap to 1.87.0

### DIFF
--- a/subprojects/leptonica.wrap
+++ b/subprojects/leptonica.wrap
@@ -1,13 +1,14 @@
 [wrap-file]
-directory = leptonica-1.84.1
-source_url = https://github.com/DanBloomberg/leptonica/releases/download/1.84.1/leptonica-1.84.1.tar.gz
-source_filename = leptonica-1.84.1.tar.gz
-source_hash = 2b3e1254b1cca381e77c819b59ca99774ff43530209b9aeb511e1d46588a64f6
-patch_filename = leptonica_1.84.1-2_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/leptonica_1.84.1-2/get_patch
-patch_hash = 9c270f153d6f94519118ace9a2ed3d22326eeb4f6992f0d2452d24804532a237
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/leptonica_1.84.1-2/leptonica-1.84.1.tar.gz
-wrapdb_version = 1.84.1-2
+directory = leptonica-1.87.0
+source_url = https://github.com/DanBloomberg/leptonica/releases/download/1.87.0/leptonica-1.87.0.tar.gz
+source_filename = leptonica-1.87.0.tar.gz
+source_hash = c73363397f96eb1295602bf44d708a994ad42046c791bf03ea0505d829bdb6a7
+source_fallback_url = https://wrapdb.mesonbuild.com/v2/leptonica_1.87.0-1/get_source/leptonica-1.87.0.tar.gz
+patch_filename = leptonica_1.87.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/leptonica_1.87.0-1/get_patch
+patch_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/leptonica_1.87.0-1/leptonica_1.87.0-1_patch.zip
+patch_hash = 9633d49f037bd296062ca9e4854d470f475a0ca268b8c6b411347e6ba2f75dfd
+wrapdb_version = 1.87.0-1
 
 [provide]
 dependency_names = lept


### PR DESCRIPTION
Ran `meson wrap update` and did a test build with `--force-fallback-for leptonica`. Appears to work. Leptonica’s own test suite also passes.