### PR TITLE
CI/meson: avoid unnecessary WINE binfmt wrapper

### DIFF
--- a/.github/workflows/meson.yaml
+++ b/.github/workflows/meson.yaml
@@ -54,7 +54,7 @@ jobs:
             pkg:
               - mingw64-cross-gcc-c++
               - mingw64-cross-pkgconf
-              - mingw64-cross-wine
+              - wine
             args:
               - --cross-file=cross.ini
               - --pkgconfig.relocatable


### PR DESCRIPTION
Only the wine package is needed. The binfmt wrapper is not necessary for Meson, as it understands how to use WINE directly.

Since the packages involved have not changed meaningfully in over a year, I can only assume the CI workflows were failing because GitHub tightened container permissions, causing binfmt wrapper registration during package install to throw errors.