### PR TITLE
CI: Release workflow

### DIFF
--- a/.github/workflows/meson.yaml
+++ b/.github/workflows/meson.yaml
@@ -61,6 +61,8 @@ jobs:
               - -Db_lto=false
               - --prefix
               - $(pwd)/artifact
+              - --licensedir
+              - .
     steps:
       - name: '🛒 Install dependencies'
         run: >
@@ -128,8 +130,7 @@ jobs:
         id: install
         if: ${{ matrix.compiler == 'mingw-w64-gcc' }}
         run: |
-          meson install -C build --skip-subprojects
-          cp COPYING artifact
+          meson install -C build
           echo "prjinfo=$(meson introspect --projectinfo build)" >> $GITHUB_OUTPUT
 
       - name: '🚀 Upload build artifact'
@@ -163,6 +164,7 @@ jobs:
           --pkgconfig.relocatable
           --buildtype debug
           --prefix "$(pwd)/artifact"
+          --licensedir .
           build
 
       - name: '🛠 Run build'
@@ -175,8 +177,7 @@ jobs:
         id: install
         shell: bash
         run: |
-          meson install -C build --skip-subprojects
-          cp COPYING artifact
+          meson install -C build
           echo "prjinfo=$(meson introspect --projectinfo build)" >> $GITHUB_OUTPUT
 
       - name: '🚀 Upload build artifact'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,118 @@
+name: release
+
+on:
+  push:
+    tags:
+      - '*'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    container:
+      image: 'registry.opensuse.org/opensuse/tumbleweed'
+      env:
+        CC: ${{ matrix.cc }}
+        CXX: ${{ matrix.cxx }}
+        CC_LD: ${{ matrix.ld }}
+        CXX_LD: ${{ matrix.ld }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [gcc]
+        include:
+          - compiler: gcc
+            cc: gcc
+            cxx: g++
+            pkg:
+              - gcc-c++
+    steps:
+      - name: '🛒 Install dependencies'
+        run: >
+          zypper -n in --no-recommends
+          meson
+          git-core
+          autoconf
+          automake
+          libtool
+          'pkgconfig(lept)'
+          ${{ join(matrix.pkg, ' ') }}
+          || [ $? -eq 107 ]
+
+      - name: '📂 Checkout'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      # checkout action UID differs from container UID
+      - name: '🙄 Tell Git to ignore workspace ownership'
+        run: git config --global --add safe.directory '*'
+
+      - name: '🚧 Configure build'
+        run: meson setup --buildtype release ${{ join(matrix.args, ' ') }} build
+
+      - name: '📦 Run dist'
+        run: meson dist -C build
+
+      - name: '🚀 Upload release archive'
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          working_directory: build/meson-dist
+          files: |
+            *.tar.*
+            *.sha256sum
+
+  windows:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['windows-2025-vs2026', 'windows-11-arm']
+    steps:
+      - name: '📂 Checkout'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: '🛒 Install dependencies'
+        run: python -m pip install meson
+
+      - name: '🚧 Configure build'
+        shell: bash
+        run: >
+          meson setup
+          --vsenv
+          --pkgconfig.relocatable
+          --buildtype release
+          --prefix "$(pwd)/artifact"
+          --licensedir .
+          build
+
+      - name: '🛠 Run build'
+        run: meson compile -C build
+
+      - name: '🔬 Run tests'
+        run: meson test -C build --print-errorlogs 'jbig2enc:'
+
+      - name: '📦 Install build artifact'
+        id: install
+        shell: bash
+        run: |
+          meson install -C build
+          echo "prjinfo=$(meson introspect --projectinfo build)" >> $GITHUB_OUTPUT
+
+      - name: '📦 Create release archive'
+        run: Compress-Archive -Path artifact/* -Destination jbig2enc-${{ fromJSON(steps.install.outputs.prjinfo)['version'] }}-${{ runner.os }}-${{ runner.arch }}-MSVC.zip
+
+      - name: '🚀 Upload release archive'
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          files: jbig2enc-${{ fromJSON(steps.install.outputs.prjinfo)['version'] }}-${{ runner.os }}-${{ runner.arch }}-MSVC.zip

--- a/meson-support/dist_buildsystems.sh
+++ b/meson-support/dist_buildsystems.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e
+
+version_clean="$1"
+version_major="$2"
+version_minor="$3"
+version_micro="$4"
+
+pat_cmake_version='set\(Version "[^"]+"\)'
+pat_ac_init='(AC_INIT\(\[[^]]+\],\[)[0-9\.]+(\],\[[^]]*\],\[jbig2enc-)[0-9\.]*'
+pat_ac_major='(GENERIC_MAJOR_VERSION=)[0-9]*'
+pat_ac_minor='(GENERIC_MINOR_VERSION=)[0-9]*'
+pat_ac_micro='(GENERIC_MICRO_VERSION=)[0-9]*'
+
+cd "$MESON_PROJECT_DIST_ROOT"
+sed -i -E "s/$pat_cmake_version/set(Version \"$version_clean\")/" CMakeLists.txt
+sed -i -E "s/$pat_ac_init/\\1$version_clean\\2$version_clean/" configure.ac
+sed -i -E "s/$pat_ac_major/\\1$version_major/;s/$pat_ac_minor/\\1$version_minor/;s/$pat_ac_micro/\\1$version_micro/" configure.ac
+
+./autogen.sh
+rm -rf autom4te.cache

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ project(
     'cpp',
     license: 'Apache-2.0',
     license_files: ['COPYING'],
-    version: run_command('meson-support'/'version.sh', 'get-vcs', check: true).stdout().strip(),
+    version: run_command('meson-support' / 'version.sh', 'get-vcs', check: true).stdout().strip(),
     meson_version: '>= 1.10.0',
     default_options: {
         'cpp_std': 'c++14',
@@ -34,8 +34,6 @@ project(
         'libz:warning_level': '0',
     },
 )
-# Cement version for dist tarballs so that git is not required.
-meson.add_dist_script('meson-support'/'version.sh', 'set-dist', meson.project_version())
 
 version_clean = meson.project_version().split('-')[0]
 version_parts = version_clean.split('.')
@@ -45,6 +43,22 @@ so_current = version_parts[0].to_int()  # increment for all API changes
 so_revision = version_parts[1].to_int()  # always increment
 so_age = version_parts.get(2, '0').to_int()  # increment only for backwards-compatible API changes
 shlib_version = '@0@.@1@.@2@'.format(so_current - so_age, so_age, so_revision)
+
+# Cement version for dist tarballs so that git is not required.
+meson.add_dist_script(
+    'meson-support' / 'version.sh',
+    'set-dist',
+    meson.project_version(),
+)
+
+# Update versions in the other buildsystems and generate Autotools.
+meson.add_dist_script(
+    'meson-support' / 'dist_buildsystems.sh',
+    version_clean,
+    version_parts[0],
+    version_parts[1],
+    version_parts.get(2, '0'),
+)
 
 cxx = meson.get_compiler('cpp')
 

--- a/meson.build
+++ b/meson.build
@@ -27,11 +27,11 @@ project(
         'libjpeg-turbo:default_library': 'static',
         'libpng:default_library': 'static',
         'libtiff:default_library': 'static',
-        'libz:default_library': 'static',
+        'zlib:default_library': 'static',
         'libjpeg-turbo:warning_level': '0',
         'libpng:warning_level': '0',
         'libtiff:warning_level': '0',
-        'libz:warning_level': '0',
+        'zlib:warning_level': '0',
     },
 )
 

--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project(
     'jbig2enc',
     'cpp',
     license: 'Apache-2.0',
-    license_files: ['COPYING', 'AUTHORS'],
+    license_files: ['COPYING'],
     version: run_command('meson-support'/'version.sh', 'get-vcs', check: true).stdout().strip(),
     meson_version: '>= 1.10.0',
     default_options: {


### PR DESCRIPTION
## Release CI Actions

Closes #117.
This will do the following whenever **any tag** is pushed:

* Creates a draft release (not published) named after the tag
* On a Linux runner: Runs `meson dist` and attaches the result to the release
* On Windows x64/ARM64 runners: Builds and attaches binaries (includes subproject dependencies)

In order for this to work, Actions **must have write permissions** configured in the repository settings.

As of this PR, the following files will be attached to a release:

* jbig2enc-${version}-Windows-ARM64-MSVC.zip
* jbig2enc-${version}-Windows-X64-MSVC.zip
* jbig2enc-${version}.tar.xz
* jbig2enc-${version}.tar.xz.sha256sum


## Dist script

`meson-support/dist_buildsystems.sh` was added to update the version information in CMake and Autotools to ensure that it matches what Meson has. It also runs `autogen.sh`, which is perhaps more useful for actual releases. These actions are only performed in the dist root, before Meson runs its build tests and the tarball is created.


### Other/Comments

I suggest using signed tags (`git tag -s`) for releases. The release Action can also set the release notes, so maybe we could just extract those using a preprocessor?