### PR TITLE
chore: update meson wraps

### DIFF
--- a/subprojects/libjpeg-turbo.wrap
+++ b/subprojects/libjpeg-turbo.wrap
@@ -1,14 +1,14 @@
 [wrap-file]
-directory = libjpeg-turbo-3.1.3
-source_url = https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/3.1.3/libjpeg-turbo-3.1.3.tar.gz
-source_filename = libjpeg-turbo-3.1.3.tar.gz
-source_hash = 075920b826834ac4ddf97661cc73491047855859affd671d52079c6867c1c6c0
-source_fallback_url = https://wrapdb.mesonbuild.com/v2/libjpeg-turbo_3.1.3-1/get_source/libjpeg-turbo-3.1.3.tar.gz
-patch_filename = libjpeg-turbo_3.1.3-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/libjpeg-turbo_3.1.3-1/get_patch
-patch_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libjpeg-turbo_3.1.3-1/libjpeg-turbo_3.1.3-1_patch.zip
-patch_hash = 4c552c743b6a16d3338cbee6ab1dc10333f19a72464e7b7c964f6e03d78f48df
-wrapdb_version = 3.1.3-1
+directory = libjpeg-turbo-3.1.4.1
+source_url = https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/3.1.4.1/libjpeg-turbo-3.1.4.1.tar.gz
+source_filename = libjpeg-turbo-3.1.4.1.tar.gz
+source_hash = ecae8008e2cc9ade2f2c1bb9d5e6d4fb73e7c433866a056bd82980741571a022
+source_fallback_url = https://wrapdb.mesonbuild.com/v2/libjpeg-turbo_3.1.4.1-1/get_source/libjpeg-turbo-3.1.4.1.tar.gz
+patch_filename = libjpeg-turbo_3.1.4.1-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/libjpeg-turbo_3.1.4.1-1/get_patch
+patch_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libjpeg-turbo_3.1.4.1-1/libjpeg-turbo_3.1.4.1-1_patch.zip
+patch_hash = 5d4093808c46da4a9e6dad19caa782157e4251e3cb941e46f63551ae6c8d2814
+wrapdb_version = 3.1.4.1-1
 
 [provide]
 dependency_names = libjpeg, libturbojpeg

--- a/subprojects/libpng.wrap
+++ b/subprojects/libpng.wrap
@@ -1,14 +1,14 @@
 [wrap-file]
-directory = libpng-1.6.55
-source_url = https://github.com/pnggroup/libpng/archive/v1.6.55.tar.gz
-source_filename = libpng-1.6.55.tar.gz
-source_hash = 71a2c5b1218f60c4c6d2f1954c7eb20132156cae90bdb90b566c24db002782a6
-source_fallback_url = https://wrapdb.mesonbuild.com/v2/libpng_1.6.55-1/get_source/libpng-1.6.55.tar.gz
-patch_filename = libpng_1.6.55-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/libpng_1.6.55-1/get_patch
-patch_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libpng_1.6.55-1/libpng_1.6.55-1_patch.zip
-patch_hash = d5754df441e93e2e2f1dc176cc86f45ec0ef2914e9c77c1e8013c68b106d0ff5
-wrapdb_version = 1.6.55-1
+directory = libpng-1.6.56
+source_url = https://github.com/pnggroup/libpng/archive/v1.6.56.tar.gz
+source_filename = libpng-1.6.56.tar.gz
+source_hash = 41d74ffe235cb7e8bab40bcad2167f7bb25edbf2231dcfff57ccf4305dc0bfae
+source_fallback_url = https://wrapdb.mesonbuild.com/v2/libpng_1.6.56-1/get_source/libpng-1.6.56.tar.gz
+patch_filename = libpng_1.6.56-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/libpng_1.6.56-1/get_patch
+patch_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libpng_1.6.56-1/libpng_1.6.56-1_patch.zip
+patch_hash = 1c8b33bc42552b40ea4cb34c09a7d50f4ff66085bde557fb9d6d3a37c894f653
+wrapdb_version = 1.6.56-1
 
 [provide]
 dependency_names = libpng

--- a/subprojects/libtiff.wrap
+++ b/subprojects/libtiff.wrap
@@ -3,11 +3,12 @@ directory = tiff-4.7.1
 source_url = https://download.osgeo.org/libtiff/tiff-4.7.1.tar.xz
 source_filename = tiff-4.7.1.tar.gz
 source_hash = b92017489bdc1db3a4c97191aa4b75366673cb746de0dce5d7a749d5954681ba
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libtiff_4.7.1-3/tiff-4.7.1.tar.gz
-patch_filename = libtiff_4.7.1-3_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/libtiff_4.7.1-3/get_patch
-patch_hash = c452f63523f02afe44eb88511a771ba5db5ace0cef5e8c0281630421969b0a87
-wrapdb_version = 4.7.1-3
+source_fallback_url = https://wrapdb.mesonbuild.com/v2/libtiff_4.7.1-4/get_source/tiff-4.7.1.tar.gz
+patch_filename = libtiff_4.7.1-4_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/libtiff_4.7.1-4/get_patch
+patch_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libtiff_4.7.1-4/libtiff_4.7.1-4_patch.zip
+patch_hash = 24e578eac0a0abd43a6bae2b5c3ffbd944e4719131832ec6452b9af610090e33
+wrapdb_version = 4.7.1-4
 
 [provide]
 dependency_names = libtiff-4


### PR DESCRIPTION
libjpeg-turbo: 3.1.3 -> 3.1.4.1
libpng: 1.6.55 -> 1.6.56
libtiff: 4.7.1-3 -> 4.7.1-4